### PR TITLE
chore: import sort 와 type consistent rule을 적용한다.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,15 @@
 {
-  "extends": ["next/core-web-vitals", "next/typescript"]
+  "extends": ["next/core-web-vitals", "next/typescript"],
+  "plugins": ["@typescript-eslint", "simple-import-sort"],
+  "rules": {
+    "simple-import-sort/imports": "error",
+    "simple-import-sort/exports": "error",
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      {
+        "prefer": "type-imports",
+        "disallowTypeAnnotations": false
+      }
+    ]
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,11 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
-        "eslint": "^8",
+        "@typescript-eslint/eslint-plugin": "^8.45.0",
+        "@typescript-eslint/parser": "^8.45.0",
+        "eslint": "^8.57.1",
         "eslint-config-next": "14.2.33",
+        "eslint-plugin-simple-import-sort": "^12.1.1",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
@@ -2281,6 +2284,15 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -9,18 +9,21 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "next": "14.2.33",
     "react": "^18",
-    "react-dom": "^18",
-    "next": "14.2.33"
+    "react-dom": "^18"
   },
   "devDependencies": {
-    "typescript": "^5",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@typescript-eslint/eslint-plugin": "^8.45.0",
+    "@typescript-eslint/parser": "^8.45.0",
+    "eslint": "^8.57.1",
+    "eslint-config-next": "14.2.33",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "eslint": "^8",
-    "eslint-config-next": "14.2.33"
+    "typescript": "^5"
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
+import "./globals.css";
+
 import type { Metadata } from "next";
 import localFont from "next/font/local";
-import "./globals.css";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",


### PR DESCRIPTION
## 작업내용
- `simple-import-sort/imports`와 `simple-import-sort/exports`를 error로 추가해 import/export 정렬을 강제
- `@typescript-eslint/consistent-type-imports`를 `prefer: 'type-imports', disallowTypeAnnotations: false` 옵션과 함께 활성화해 타입 전용 모듈은 import type을 사용하되 기존 타입 주석 패턴은 허용


## 관련 링크
- [simple-import-sort 문서](https://github.com/lydell/eslint-plugin-simple-import-sort)
- [@typescript-eslint/consistent-type-imports 문서](https://typescript-eslint.io/rules/consistent-type-imports/)

