### PR TITLE
Chore/set bff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CI: true
+      FINNHUB_API_BASE_URL: ${{ vars.FINNHUB_API_BASE_URL }}
+      FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
+      ALPHAVANTAGE_API_BASE_URL: ${{ vars.ALPHAVANTAGE_API_BASE_URL }}
+      ALPHAVANTAGE_API_KEY: ${{ secrets.ALPHAVANTAGE_API_KEY }}
+      FINANCIAL_MODELING_PREP_API_BASE_URL: ${{ vars.FINANCIAL_MODELING_PREP_API_BASE_URL }}
+      FINANCIAL_MODELING_PREP_API_KEY: ${{ secrets.FINANCIAL_MODELING_PREP_API_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,10 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
+.env.*
 .env*.local
+!.env.example
 
 # vercel
 .vercel

--- a/app/api/symbol-search/route.ts
+++ b/app/api/symbol-search/route.ts
@@ -1,0 +1,28 @@
+import type { NextRequest, NextResponse } from "next/server";
+
+import { ValidationError } from "@/shared/api/server/errors/base-error";
+import { fail } from "@/shared/api/server/http/error-response";
+import { ok } from "@/shared/api/server/http/success-response";
+import {
+  API_PROVIDER,
+  type ApiProvider,
+} from "@/shared/api/server/provider/api-provider";
+import { searchSymbols } from "@/shared/api/server/service/symbol.service";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const provider: ApiProvider = API_PROVIDER.FINNHUB;
+  const { searchParams } = new URL(request.url);
+  const symbol = searchParams.get("symbol") ?? "";
+
+  if (!symbol) return fail(new ValidationError("Symbol is required"));
+
+  try {
+    const result = await searchSymbols(provider, symbol);
+    return ok(result, provider);
+  } catch (error) {
+    return fail(error, provider);
+  }
+}

--- a/src/shared/api/server/adapter/symbol.adapter.ts
+++ b/src/shared/api/server/adapter/symbol.adapter.ts
@@ -1,0 +1,19 @@
+import type { FinnhubSymbolResult, Symbol } from "@/shared/domain/symbol";
+
+import { ValidationError } from "../errors/base-error";
+
+/** Finnhub 응답을 도메인 심볼 리스트로 변환 */
+export const toSymbols = (payload: FinnhubSymbolResult): Symbol[] => {
+  try {
+    return payload.result.map((item) => ({
+      description: item.description,
+      displaySymbol: item.displaySymbol,
+      symbol: item.symbol,
+      type: item.type,
+    }));
+  } catch (error) {
+    const originalMessage =
+      error instanceof Error ? error.message : String(error);
+    throw new ValidationError(originalMessage, { cause: originalMessage });
+  }
+};

--- a/src/shared/api/server/errors/base-error.ts
+++ b/src/shared/api/server/errors/base-error.ts
@@ -1,0 +1,36 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export class BaseError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string, // 내부 에러 코드 키 (로그/매핑용)
+    public readonly meta?: Record<string, any> // 디버깅용(민감정보 주의)
+  ) {
+    super(message);
+    this.name = new.target.name;
+  }
+}
+
+export class NetworkError extends BaseError {
+  constructor(message = "Network error", meta?: Record<string, any>) {
+    super(message, "ERR.NETWORK", meta);
+  }
+}
+
+export class TimeoutError extends BaseError {
+  constructor(message = "Request timeout", meta?: Record<string, any>) {
+    super(message, "ERR.NETWORK.TIMEOUT", meta);
+  }
+}
+
+export class ValidationError extends BaseError {
+  constructor(message = "Invalid request", meta?: Record<string, any>) {
+    super(message, "ERR.VALIDATION", meta);
+  }
+}
+
+export class ServiceError extends BaseError {
+  constructor(message = "Service error", meta?: Record<string, any>) {
+    super(message, "ERR.SERVICE", meta);
+  }
+}

--- a/src/shared/api/server/errors/base-error.ts
+++ b/src/shared/api/server/errors/base-error.ts
@@ -6,8 +6,7 @@ export class BaseError extends Error {
     public readonly code: string, // 내부 에러 코드 키 (로그/매핑용)
     public readonly meta?: Record<string, any> // 디버깅용(민감정보 주의)
   ) {
-    super(message);
-    this.name = new.target.name;
+    super(`[${code}]: ${message}`);
   }
 }
 

--- a/src/shared/api/server/errors/bff-error.ts
+++ b/src/shared/api/server/errors/bff-error.ts
@@ -1,0 +1,42 @@
+import type { ApiProvider } from "@/shared/api/server/provider/api-provider";
+
+import type { CanonicalStatus } from "./error-codes";
+import { toHttpCode } from "./error-codes";
+
+export type BffError = {
+  /** 성공여부 */
+  ok: false;
+  /** API 공급자 식별 ex) FMP(Financial Moeling Prep), Alphavantage, etc. */
+  provider: ApiProvider;
+  /** 요청 ID */
+  requestId: string;
+  /** HTTP code */
+  code: number;
+  /** 정규화된 HTTP 상태 */
+  status: CanonicalStatus;
+  /** 사용자/디버깅용 기본 메시지 */
+  message: string;
+  /** 클라이언트 재시도 가능 여부 */
+  retryable?: boolean;
+  /** 응답 직렬화 시각 */
+  timestamp: string;
+};
+
+export const toBffError = (
+  provider: ApiProvider,
+  status: CanonicalStatus,
+  msg: string,
+  opt?: {
+    retryable?: boolean;
+    requestId?: string;
+  }
+): BffError => ({
+  ok: false,
+  provider,
+  requestId: opt?.requestId ?? crypto.randomUUID(),
+  code: toHttpCode(status),
+  status: status,
+  message: msg,
+  retryable: opt?.retryable,
+  timestamp: new Date().toISOString(),
+});

--- a/src/shared/api/server/errors/error-codes.ts
+++ b/src/shared/api/server/errors/error-codes.ts
@@ -1,0 +1,80 @@
+export const CANONICAL_STATUS = {
+  /** 요청 속도 제한 초과 */
+  RATE_LIMITED: "RATE_LIMITED",
+  /** 잘못된 요청 */
+  INVALID_REQUEST: "INVALID_REQUEST",
+  /** 인증 실패 */
+  UNAUTHORIZED: "UNAUTHORIZED",
+  /** 권한 없음 */
+  FORBIDDEN: "FORBIDDEN",
+  /** 찾을 수 없음 */
+  NOT_FOUND: "NOT_FOUND",
+  /** 요청 시간 초과 */
+  TIMEOUT: "TIMEOUT",
+  /** 네트워크 오류 */
+  NETWORK_ERROR: "NETWORK_ERROR",
+  /** 공급자 오류 */
+  PROVIDER_ERROR: "PROVIDER_ERROR",
+  /** 잘못된 응답 */
+  BAD_RESPONSE: "BAD_RESPONSE",
+  /** 스키마 검증 실패 */
+  SCHEMA_VALIDATION_FAILED: "SCHEMA_VALIDATION_FAILED",
+  /** 내부 오류 */
+  INTERNAL_ERROR: "INTERNAL_ERROR",
+} as const;
+
+export type CanonicalStatus =
+  (typeof CANONICAL_STATUS)[keyof typeof CANONICAL_STATUS];
+
+export function toCanonicalStatus(status: number): CanonicalStatus {
+  switch (status) {
+    case 400:
+      return CANONICAL_STATUS.INVALID_REQUEST;
+    case 401:
+      return CANONICAL_STATUS.UNAUTHORIZED;
+    case 403:
+      return CANONICAL_STATUS.FORBIDDEN;
+    case 404:
+      return CANONICAL_STATUS.NOT_FOUND;
+    case 408:
+      return CANONICAL_STATUS.TIMEOUT; // client-side idle
+    case 429:
+      return CANONICAL_STATUS.RATE_LIMITED;
+    case 500:
+      return CANONICAL_STATUS.INTERNAL_ERROR;
+    case 502:
+    case 503:
+      return CANONICAL_STATUS.PROVIDER_ERROR;
+    case 504:
+      return CANONICAL_STATUS.TIMEOUT; // upstream timeout
+    default:
+      if (status >= 500) return CANONICAL_STATUS.PROVIDER_ERROR;
+      return CANONICAL_STATUS.INTERNAL_ERROR;
+  }
+}
+
+export function toHttpCode(status: string): number {
+  switch (status) {
+    case CANONICAL_STATUS.SCHEMA_VALIDATION_FAILED:
+      return 422;
+    case CANONICAL_STATUS.BAD_RESPONSE:
+    case CANONICAL_STATUS.INVALID_REQUEST:
+      return 400;
+    case CANONICAL_STATUS.UNAUTHORIZED:
+      return 401;
+    case CANONICAL_STATUS.FORBIDDEN:
+      return 403;
+    case CANONICAL_STATUS.NOT_FOUND:
+      return 404;
+    case CANONICAL_STATUS.TIMEOUT:
+      return 504;
+    case CANONICAL_STATUS.RATE_LIMITED:
+      return 429;
+    case CANONICAL_STATUS.NETWORK_ERROR:
+    case CANONICAL_STATUS.PROVIDER_ERROR:
+      return 502;
+    case CANONICAL_STATUS.INTERNAL_ERROR:
+    default:
+      return 500;
+  }
+}

--- a/src/shared/api/server/errors/provider-error.ts
+++ b/src/shared/api/server/errors/provider-error.ts
@@ -1,0 +1,84 @@
+import type { ApiProvider } from "@/shared/api/server/provider/api-provider";
+
+import type { BffError } from "./bff-error";
+import { toBffError } from "./bff-error";
+import { CANONICAL_STATUS } from "./error-codes";
+
+export class ProviderError extends Error {
+  readonly code: number;
+  readonly body: string;
+  readonly provider: ApiProvider;
+  readonly url: string;
+
+  constructor(
+    code: number,
+    body: string,
+    { provider, url }: { provider: ApiProvider; url: string }
+  ) {
+    super(`Provider responded with HTTP ${code}`);
+    this.name = "ProviderHttpError";
+    this.code = code;
+    this.body = body;
+    this.provider = provider;
+    this.url = url;
+  }
+}
+
+export const normalizeProviderError = (
+  provider: ApiProvider,
+  error: ProviderError
+): BffError => {
+  if (error.code === 429) {
+    return toBffError(
+      provider,
+      CANONICAL_STATUS.RATE_LIMITED,
+      "Rate limit exceeded. Please try again later.",
+      {
+        retryable: true,
+      }
+    );
+  }
+
+  if (error.code === 404) {
+    return toBffError(
+      provider,
+      CANONICAL_STATUS.NOT_FOUND,
+      "Requested resource was not found.",
+      {
+        retryable: false,
+      }
+    );
+  }
+
+  if (error.code === 401 || error.code === 403) {
+    return toBffError(
+      provider,
+      CANONICAL_STATUS.UNAUTHORIZED,
+      "Provider authentication failed. Please verify credentials.",
+      { retryable: false }
+    );
+  }
+
+  if (error.code >= 400 && error.code < 500) {
+    return toBffError(
+      provider,
+      CANONICAL_STATUS.INVALID_REQUEST,
+      "Invalid request was sent to provider. Check input values.",
+      { retryable: false }
+    );
+  }
+
+  // Not Implemented
+  const is501 = error.code === 501;
+  // Upstream Timeout
+  const is504 = error.code === 504;
+
+  return toBffError(
+    provider,
+    is504 ? CANONICAL_STATUS.TIMEOUT : CANONICAL_STATUS.PROVIDER_ERROR,
+    is504
+      ? "Upstream timeout. Please retry later."
+      : "Provider service is temporarily unavailable. Please retry later.",
+    { retryable: !is501 }
+  );
+};

--- a/src/shared/api/server/http/authorization.ts
+++ b/src/shared/api/server/http/authorization.ts
@@ -1,0 +1,113 @@
+import type { RetryPolicy } from "@/shared/api/server/http/retry-policy";
+import {
+  API_PROVIDER,
+  type ApiProvider,
+  type ApiProviderConfig,
+  getApiProviderConfig,
+} from "@/shared/api/server/provider/api-provider";
+
+/** fetcher에서 사용하는 옵션 확장 */
+export type FetcherOptions = RequestInit & {
+  provider?: ApiProvider;
+  timeoutMillis?: number;
+  retry?: RetryPolicy;
+};
+
+/** 인증 처리에 필요한 정보 모음 */
+type AuthorizationContext = {
+  url: string;
+  options: FetcherOptions;
+  provider: ApiProvider;
+  config: ApiProviderConfig;
+};
+
+/** 인증 처리가 끝난 결과 */
+type AuthorizationResult = {
+  url: string;
+  options: FetcherOptions;
+};
+
+/** 공급자별 인증 처리기 시그니처 */
+type AuthorizationHandler = (
+  context: AuthorizationContext
+) => AuthorizationResult;
+
+/** 별도 인증이 필요 없는 경우 passthrough */
+const passthroughAuthorization: AuthorizationHandler = ({ url, options }) => ({
+  url,
+  options,
+});
+
+/** 헤더 기반 인증 (예: Finnhub) */
+const authorizeWithHeader =
+  (headerName: string): AuthorizationHandler =>
+  ({ url, options, config }) => {
+    const headers = new Headers(options.headers ?? {});
+    headers.set(headerName, config.apiKey);
+
+    return {
+      url,
+      options: {
+        ...options,
+        headers,
+      },
+    };
+  };
+
+/** 쿼리 파라미터로 API 키 추가 */
+const appendSearchParam = (url: string, key: string, value: string): string => {
+  try {
+    const parsed = new URL(url);
+    parsed.searchParams.set(key, value);
+    return parsed.toString();
+  } catch {
+    const [base, query = ""] = url.split("?");
+    const searchParams = new URLSearchParams(query);
+    searchParams.set(key, value);
+    const queryString = searchParams.toString();
+    return queryString ? `${base}?${queryString}` : base;
+  }
+};
+
+/** 쿼리 파라미터 기반 인증 */
+const authorizeWithQuery =
+  (paramName: string): AuthorizationHandler =>
+  ({ url, options, config }) => ({
+    url: appendSearchParam(url, paramName, config.apiKey),
+    options: {
+      ...options,
+    },
+  });
+
+/** 공급자별 인증 전략 매핑 */
+const AUTHORIZATION_HANDLERS: Record<ApiProvider, AuthorizationHandler> = {
+  [API_PROVIDER.NONE]: passthroughAuthorization,
+  [API_PROVIDER.FINNHUB]: authorizeWithHeader("X-Finnhub-Token"),
+  [API_PROVIDER.ALPHAVANTAGE]: authorizeWithQuery("apikey"),
+  [API_PROVIDER.FMP]: authorizeWithQuery("apikey"),
+};
+
+/** 공급자 설정에 따라 인증 부여 */
+export function setAuthorization({
+  url,
+  options,
+  provider,
+}: {
+  url: string;
+  options: FetcherOptions;
+  provider: ApiProvider;
+}): AuthorizationResult {
+  if (provider === API_PROVIDER.NONE) {
+    return { url, options };
+  }
+
+  const config = getApiProviderConfig(provider);
+  const handler = AUTHORIZATION_HANDLERS[provider] ?? passthroughAuthorization;
+
+  return handler({
+    url,
+    options,
+    provider,
+    config,
+  });
+}

--- a/src/shared/api/server/http/error-response.ts
+++ b/src/shared/api/server/http/error-response.ts
@@ -1,0 +1,64 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { NextResponse } from "next/server";
+
+import {
+  BaseError,
+  NetworkError,
+  TimeoutError,
+} from "@/shared/api/server/errors/base-error";
+import { toBffError } from "@/shared/api/server/errors/bff-error";
+import { CANONICAL_STATUS } from "@/shared/api/server/errors/error-codes";
+import {
+  normalizeProviderError,
+  ProviderError,
+} from "@/shared/api/server/errors/provider-error";
+import {
+  API_PROVIDER,
+  type ApiProvider,
+} from "@/shared/api/server/provider/api-provider";
+
+/** error 유형에 따라 NextResponse 반환 */
+export function fail(err: any, provider: ApiProvider = API_PROVIDER.NONE) {
+  if (err instanceof ProviderError) {
+    const apiError = normalizeProviderError(provider, err);
+    return NextResponse.json(apiError, { status: apiError.code });
+  }
+
+  if (err instanceof TimeoutError) {
+    const apiError = toBffError(
+      provider,
+      CANONICAL_STATUS.TIMEOUT,
+      err.message,
+      { retryable: true }
+    );
+    return NextResponse.json(apiError, { status: apiError.code });
+  }
+
+  if (err instanceof NetworkError) {
+    const apiError = toBffError(
+      provider,
+      CANONICAL_STATUS.NETWORK_ERROR,
+      err.message,
+      { retryable: true }
+    );
+    return NextResponse.json(apiError, { status: apiError.code });
+  }
+
+  if (err instanceof BaseError) {
+    const apiError = toBffError(
+      provider,
+      CANONICAL_STATUS.INTERNAL_ERROR,
+      err.message,
+      { retryable: false }
+    );
+    return NextResponse.json(apiError, { status: apiError.code });
+  }
+
+  const apiError = toBffError(
+    provider,
+    CANONICAL_STATUS.INTERNAL_ERROR,
+    err?.message ?? "Unknown error",
+    { retryable: false }
+  );
+  return NextResponse.json(apiError, { status: apiError.code });
+}

--- a/src/shared/api/server/http/http-client.ts
+++ b/src/shared/api/server/http/http-client.ts
@@ -1,0 +1,124 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  NetworkError,
+  TimeoutError,
+} from "@/shared/api/server/errors/base-error";
+import { type BffError } from "@/shared/api/server/errors/bff-error";
+import { ProviderError } from "@/shared/api/server/errors/provider-error";
+import { type BffSuccess } from "@/shared/api/server/http/success-response";
+import {
+  API_PROVIDER,
+  type ApiProvider,
+} from "@/shared/api/server/provider/api-provider";
+
+import { type FetcherOptions, setAuthorization } from "./authorization";
+import { backoff, DEFAULT_RETRY, sleep } from "./retry-policy";
+
+export type Result<T> = BffSuccess<T> | BffError;
+
+/** 기본 타임아웃 시간 (10초) */
+const DEFAULT_TIMEOUT_MILLIS = 10_000;
+
+/** fetch + timeout */
+export async function withTimeout(
+  url: string,
+  options: FetcherOptions
+): Promise<Response> {
+  const timeoutMs = options.timeoutMillis ?? DEFAULT_TIMEOUT_MILLIS;
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(url, { ...options, signal: controller.signal });
+    return res;
+  } finally {
+    clearTimeout(id);
+  }
+}
+
+/** fetch + timeout + retry */
+export async function withRetry(
+  url: string,
+  options: FetcherOptions = {}
+): Promise<Response> {
+  const retry = options.retry ?? DEFAULT_RETRY;
+  const method = String(options.method || "GET").toUpperCase();
+
+  let attempt = 0;
+  let lastError: unknown;
+
+  while (attempt <= retry.retries) {
+    try {
+      const res = await withTimeout(url, options);
+      // 재시도 대상 판단
+      if (!retry.retryOn({ status: res.status, method })) return res;
+
+      // 재시도 하더라도 한 번 더 시도 가능하면 백오프 후 루프
+      attempt++;
+      if (attempt > retry.retries) return res;
+      await sleep(backoff(attempt, retry));
+      continue;
+    } catch (err) {
+      lastError = err;
+      // AbortError는 여기서는 "오류"로 보고 retryOn에게 넘김
+      const canRetry = retry.retryOn({ error: err, method });
+      attempt++;
+
+      if (!canRetry || attempt > retry.retries) throw err;
+      await sleep(backoff(attempt, retry));
+    }
+  }
+
+  // 정상적으로는 도달하지 않음
+  throw lastError ?? new Error("fetcher exhausted without response");
+}
+
+export const fetcher = async <T>(
+  url: string,
+  options: FetcherOptions = {}
+): Promise<T> => {
+  const provider: ApiProvider = options.provider ?? API_PROVIDER.NONE;
+
+  const { url: authorizedUrl, options: authorizedOptions } = setAuthorization({
+    url,
+    options,
+    provider,
+  });
+
+  try {
+    const res = await withRetry(authorizedUrl, authorizedOptions);
+    const text = await res.text();
+
+    if (!res.ok) {
+      // 공급자 에러 로깅
+      console.error("[UPSTREAM ERROR]", {
+        provider,
+        url: authorizedUrl,
+        status: res.status,
+        body: text.slice(0, 300), // full body logging 금지
+      });
+
+      throw new ProviderError(res.status, text, { provider, url });
+    }
+    return JSON.parse(text);
+  } catch (e: any) {
+    // BFF, fetcher 에러 로깅
+    console.error("[UPSTREAM FAIL]", {
+      provider,
+      url: authorizedUrl,
+      error: e.message,
+      type: e.name,
+    });
+
+    // withTimeout에서 AbortError가 발생한 경우
+    if (e.name === "AbortError")
+      throw new TimeoutError("Fetch aborted by timeout", { provider, url });
+
+    // fetch는 네트워크 실패 시 TypeError를 던짐
+    if (e instanceof TypeError)
+      throw new NetworkError(e.message, { provider, url });
+
+    // ProviderError 등은 그대로 전파
+    throw e;
+  }
+};

--- a/src/shared/api/server/http/retry-policy.ts
+++ b/src/shared/api/server/http/retry-policy.ts
@@ -1,0 +1,54 @@
+export const JITTER_METHOD = {
+  NONE: "none",
+  FULL: "full",
+} as const;
+
+export type JitterMethod = (typeof JITTER_METHOD)[keyof typeof JITTER_METHOD];
+
+export type RetryPolicy = {
+  /** 추가 재시도 횟수 (총 시도 = retries+1) */
+  retries: number;
+  /** 첫 백오프 */
+  baseDelayMs: number;
+  /** 백오프 상한 */
+  maxDelayMs: number;
+  /** 지터 방식 */
+  jitter?: JitterMethod;
+  /** 재시도 여부 결정 훅 (상태코드/오류/메서드 기반) */
+  retryOn: (ctx: {
+    status?: number;
+    error?: unknown;
+    method?: string;
+  }) => boolean;
+};
+
+export const DEFAULT_RETRY: RetryPolicy = {
+  retries: 2,
+  baseDelayMs: 300,
+  maxDelayMs: 2_000,
+  jitter: JITTER_METHOD.FULL,
+  retryOn: ({ status, error, method }) => {
+    // 안전하지 않은 메서드(POST/PUT/PATCH/DELETE)는 기본적으로 재시도 안 함
+    const unsafe = ["POST", "PUT", "PATCH", "DELETE"];
+    if (unsafe.includes(String(method || "GET").toUpperCase())) return false;
+
+    // 상태코드 기반(429/5xx) 또는 네트워크 오류만 재시도
+    if (typeof status === "number") {
+      if (status === 429) return true;
+      if (status >= 500 && status <= 599) return true;
+      return false;
+    }
+    // fetch throw (네트워크/Abort 등)
+    return !!error;
+  },
+};
+
+export const sleep = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+export const backoff = (attempt: number, p: RetryPolicy) => {
+  const raw = Math.min(p.baseDelayMs * 2 ** (attempt - 1), p.maxDelayMs);
+
+  // full jitter 방식
+  if (p.jitter === "full") return Math.random() * raw;
+  return raw;
+};

--- a/src/shared/api/server/http/success-response.ts
+++ b/src/shared/api/server/http/success-response.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+
+import {
+  API_PROVIDER,
+  type ApiProvider,
+} from "@/shared/api/server/provider/api-provider";
+
+export type BffSuccess<T> = {
+  ok: true;
+  data: T;
+  provider: ApiProvider;
+  requestId: string;
+  timestamp: string;
+};
+
+export const toBffSuccess = <T>(
+  provider: ApiProvider,
+  data: T,
+  requestId = crypto.randomUUID()
+): BffSuccess<T> => ({
+  ok: true,
+  provider,
+  data,
+  requestId,
+  timestamp: new Date().toISOString(),
+});
+
+/** NextResponse.json 래퍼 */
+export function ok<T>(
+  data: T,
+  provider: ApiProvider = API_PROVIDER.NONE
+): NextResponse<BffSuccess<T>> {
+  return NextResponse.json(toBffSuccess(provider, data), { status: 200 });
+}

--- a/src/shared/api/server/provider/api-provider.ts
+++ b/src/shared/api/server/provider/api-provider.ts
@@ -1,0 +1,47 @@
+/** API 공급자 관련 설정 */
+import "server-only";
+
+export const API_PROVIDER = {
+  /** Financial Moeling Prep - 250 Calls / Day */
+  FMP: "FMP",
+  /** Alphavantage - 25 Calls / Day */
+  ALPHAVANTAGE: "ALPHAVANTAGE",
+  /** Finnhub - 30 Calls / Seconds & 60 Calls / Minute */
+  FINNHUB: "FINNHUB",
+  /** 사용하지 않는 공급자 */
+  NONE: "NONE",
+} as const;
+
+export type ApiProvider = (typeof API_PROVIDER)[keyof typeof API_PROVIDER];
+
+/**
+ * API 공급자 설정 객체
+ *
+ * @key API_PROVIDER
+ * @value { baseUrl: string; apiKey: string; }
+ */
+export const API_PROVIDER_CONFIG = {
+  FMP: {
+    baseUrl: process.env.FINANCIAL_MODELING_PREP_API_BASE_URL!,
+    apiKey: process.env.FINANCIAL_MODELING_PREP_API_KEY!,
+  },
+  ALPHAVANTAGE: {
+    baseUrl: process.env.ALPHAVANTAGE_API_BASE_URL!,
+    apiKey: process.env.ALPHAVANTAGE_API_KEY!,
+  },
+  FINNHUB: {
+    baseUrl: process.env.FINNHUB_API_BASE_URL!,
+    apiKey: process.env.FINNHUB_API_KEY!,
+  },
+  NONE: {
+    baseUrl: "",
+    apiKey: "",
+  },
+} as const;
+
+export type ApiProviderConfig =
+  (typeof API_PROVIDER_CONFIG)[keyof typeof API_PROVIDER_CONFIG];
+
+export const getApiProviderConfig = (provider: ApiProvider) => {
+  return API_PROVIDER_CONFIG[provider];
+};

--- a/src/shared/api/server/service/symbol.service.ts
+++ b/src/shared/api/server/service/symbol.service.ts
@@ -1,0 +1,31 @@
+import { fetcher } from "@/shared/api/server/http/http-client";
+import {
+  type ApiProvider,
+  getApiProviderConfig,
+} from "@/shared/api/server/provider/api-provider";
+import type { FinnhubSymbolResult, Symbol } from "@/shared/domain/symbol";
+
+/** Finnhub 응답을 도메인 심볼 리스트로 변환 */
+export const toSymbols = (payload: FinnhubSymbolResult): Symbol[] => {
+  return payload.result.map((item) => ({
+    description: item.description,
+    displaySymbol: item.displaySymbol,
+    symbol: item.symbol,
+    type: item.type,
+  }));
+};
+
+/** 공급자 심볼 검색 */
+export const searchSymbols = async (
+  provider: ApiProvider,
+  query: string
+): Promise<Symbol[]> => {
+  const { baseUrl } = getApiProviderConfig(provider);
+
+  const raw = await fetcher<FinnhubSymbolResult>(
+    `${baseUrl}/search?q=${query}`,
+    { provider }
+  );
+
+  return toSymbols(raw);
+};

--- a/src/shared/api/server/service/symbol.service.ts
+++ b/src/shared/api/server/service/symbol.service.ts
@@ -5,15 +5,7 @@ import {
 } from "@/shared/api/server/provider/api-provider";
 import type { FinnhubSymbolResult, Symbol } from "@/shared/domain/symbol";
 
-/** Finnhub 응답을 도메인 심볼 리스트로 변환 */
-export const toSymbols = (payload: FinnhubSymbolResult): Symbol[] => {
-  return payload.result.map((item) => ({
-    description: item.description,
-    displaySymbol: item.displaySymbol,
-    symbol: item.symbol,
-    type: item.type,
-  }));
-};
+import { toSymbols } from "../adapter/symbol.adapter";
 
 /** 공급자 심볼 검색 */
 export const searchSymbols = async (

--- a/src/shared/domain/symbol.ts
+++ b/src/shared/domain/symbol.ts
@@ -1,0 +1,31 @@
+export type FinnhubSymbol = {
+  /** 설명 - ex) APPLE INC */
+  description: string;
+  /** 표시 심볼 - ex) AAPL */
+  displaySymbol: string;
+  /** 심볼 - ex) AAPL */
+  symbol: string;
+  /** 타입 - ex) Common Stock */
+  type: string;
+};
+
+export type FinnhubSymbolResult = {
+  count: number;
+  result: FinnhubSymbol[];
+};
+
+export type Symbol = {
+  /** 설명 - ex) APPLE INC */
+  description: string;
+  /** 표시 심볼 - ex) AAPL */
+  displaySymbol: string;
+  /** 심볼 - ex) AAPL */
+  symbol: string;
+  /** 타입 - ex) Common Stock */
+  type: string;
+};
+
+export type SymbolSearchResult = {
+  count: number;
+  result: Symbol[];
+};


### PR DESCRIPTION
## 📌 Summary

- BFF 아키텍처 설계

## 🧩 Details

- route handler(controller) → service(adapter) → fetcher(timeout + retry) 3계층 구조로 역할을 분리하여 책임 명확
- 오픈 API의 기본 URL과 Key를 process.env 환경변수로 주입해 배포 환경마다 설정만으로 교체 가능
- 오픈 API의 기본 URL과 Key를 process.env 환경변수로 주입하고, GitHub Actions 파이프라인에도 환경변수 등록
- fetcher 단계에서 timeout·retry 정책을 적용
- Provider(API 공급자) 오류는 프로젝트 표준 에러로 래핑하여 표준화
- timeout·네트워크·파싱 등 제어 불가 오류까지 포괄해 BFF 응답 포맷으로 표준화
- `Finnhub`의 SymbolSearch API를 구현하여 테스트 진행
  - Success Response
  - <img width="495" height="824" alt="image" src="https://github.com/user-attachments/assets/af9582f4-1ce1-4ce8-9ab3-f87b9ea705e5" />
  - Error Response
  - <img width="495" height="209" alt="image" src="https://github.com/user-attachments/assets/868d73b4-c1ca-494b-b23d-389ecb8df8a9" />



## ✅ Check

- [x] 기능 정상 동작

---

### ℹ️ 템플릿 안내

본 PR 템플릿은 **프로젝트의 성장과 요구사항 변화에 따라 지속적으로 업데이트**될 수 있음
